### PR TITLE
Correct README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,25 @@ Bindings to JavaScript's built in HTTP client, `fetch`.
 import gleam/fetch
 import gleam/http.{Get}
 import gleam/http/request
-import gleam/http/response
+import gleam/http/response.{Response}
 import gleam/javascript/promise.{try_await}
 
 pub fn main() {
   // Prepare a HTTP request record
-  let request = request.new()
+  let req = request.new()
     |> request.set_method(Get)
     |> request.set_host("test-api.service.hmrc.gov.uk")
     |> request.set_path("/hello/world")
     |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
 
   // Send the HTTP request to the server
-  use response <- try_await(fetch.send(request))
-  use response <- try_await(fetch.read_text_body(response))
+  use resp <- try_await(fetch.send(req))
+  use resp <- try_await(fetch.read_text_body(resp))
 
   // We get a response record back
-  assert Response(status: 200, ..) = response
+  assert Response(status: 200, ..) = resp
 
-  assert Ok("text/html; charset=utf-8") =
-    http.get_resp_header(resp, "content-type")
-
+  assert Ok("application/json") = response.get_header(resp, "content-type")
   assert "{\"message\":\"Hello World\"}" = resp.body
 
   promise.resolve(Ok(Nil))

--- a/test/gleam_fetch_test.gleam
+++ b/test/gleam_fetch_test.gleam
@@ -77,12 +77,12 @@ pub fn head_request_discards_body_test() {
 
   use response <- promise.try_await(fetch.send(request))
   use response <- promise.await(fetch.read_text_body(response))
-    assert Ok(resp) = response
-    assert 200 = resp.status
-    assert Ok("application/json; charset=utf-8") =
-      response.get_header(resp, "content-type")
-    assert "" = resp.body
-    promise.resolve(Ok(Nil))
+  assert Ok(resp) = response
+  assert 200 = resp.status
+  assert Ok("application/json; charset=utf-8") =
+    response.get_header(resp, "content-type")
+  assert "" = resp.body
+  promise.resolve(Ok(Nil))
 }
 
 pub fn options_request_discards_body_test() {


### PR DESCRIPTION
Fix broken example in `README.md` and also fix bad code formatting that broke the build. Further, in the example, renamed variables `request` and `response` to `req` and `resp`, respectively, to avoid confusion with modules of the same name. While the duplicative names do not cause any compilation or runtime failures, they do cause confusion for the reader.