### PR TITLE
Support passing options to fetch

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -3,9 +3,9 @@
 
 packages = [
   { name = "gleam_http", version = "3.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FAE9AE3EB1CA90C2194615D20FFFD1E28B630E84DACA670B28D959B37BCBB02C" },
-  { name = "gleam_javascript", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "9FBC0BA8E15355B1CAA2775109E1E05EA0950D0FF451A8AFD41BDD972C3652A1" },
-  { name = "gleam_stdlib", version = "0.30.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "03710B3DA047A3683117591707FCA19D32B980229DD8CE8B0603EB5B5144F6C3" },
-  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
+  { name = "gleam_javascript", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "BFEBB63ABE4A1694E07DEFD19B160C2980304B5D775A89D4B02E7DE7C9D8008B" },
+  { name = "gleam_stdlib", version = "0.30.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "8D8BF3790AA31176B1E1C0B517DD74C86DA8235CF3389EA02043EE4FD82AE3DC" },
+  { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
 ]
 
 [requirements]

--- a/src/ffi.mjs
+++ b/src/ffi.mjs
@@ -17,6 +17,14 @@ export async function raw_send(request) {
   }
 }
 
+export async function raw_send_with_options(request, options) {
+  try {
+    return new Ok(await fetch(request, options));
+  } catch (error) {
+    return new Error(new NetworkError(error.toString()));
+  }
+}
+
 export function from_fetch_response(response) {
   return new Response(
     response.status,
@@ -59,4 +67,12 @@ export async function read_json_body(response) {
   } catch (error) {
     return new Error(new InvalidJsonBody());
   }
+}
+
+export function make_options() {
+  return {}
+}
+
+export function update_options(options, key, value) {
+  return { ...options, [key]: value }
 }

--- a/src/gleam/fetch.gleam
+++ b/src/gleam/fetch.gleam
@@ -13,10 +13,18 @@ pub type FetchBody
 
 pub type FetchRequest
 
+pub type FetchRequestOptions
+
 pub type FetchResponse
 
 @external(javascript, "../ffi.mjs", "raw_send")
 pub fn raw_send(a: FetchRequest) -> Promise(Result(FetchResponse, FetchError))
+
+@external(javascript, "../ffi.mjs", "raw_send_with_options")
+pub fn raw_send_with_options(
+  a: FetchRequest,
+  b: FetchRequestOptions,
+) -> Promise(Result(FetchResponse, FetchError))
 
 pub fn send(
   request: Request(String),
@@ -44,3 +52,31 @@ pub fn read_text_body(
 pub fn read_json_body(
   a: Response(FetchBody),
 ) -> Promise(Result(Response(Dynamic), FetchError))
+
+@external(javascript, "../ffi.mjs", "make_options")
+pub fn make_options() -> FetchRequestOptions
+
+@external(javascript, "../ffi.mjs", "update_options")
+fn update_options(
+  a: FetchRequestOptions,
+  key: String,
+  value: Dynamic,
+) -> FetchRequestOptions
+
+pub type CredentialsOption {
+  Include
+  SameOrigin
+  Omit
+}
+
+pub fn with_credentials(
+  o: FetchRequestOptions,
+  v: CredentialsOption,
+) -> FetchRequestOptions {
+  let encoded_value = case v {
+    Include -> "include"
+    SameOrigin -> "same-origin"
+    Omit -> "omit"
+  }
+  update_options(o, "credentials", dynamic.from(encoded_value))
+}


### PR DESCRIPTION
The goal of this PR is to enable passing advanced options to fetch, as discussed in issue $4. For now it's just the `credentials` option. Once we decide how to handle code structure and naming, I'll add support more fetch options.
