### PR TITLE
Read `rawBuffer` for BitArray body instead of `buffer`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: false
-          gleam-version: "1.8.1"
+          gleam-version: "1.9.1"
       - run: gleam test
       - run: gleam format --check src test

--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "1.2.0"
 licences = ["Apache-2.0"]
 description = "Make HTTP requests in Gleam JavaScript with Fetch"
 target = "javascript"
-gleam = ">= 0.32.0"
+gleam = ">= 1.9.0"
 
 repository = { type = "github", user = "gleam-lang", repo = "fetch" }
 links = [

--- a/src/gleam_fetch_ffi.mjs
+++ b/src/gleam_fetch_ffi.mjs
@@ -51,7 +51,7 @@ export function form_data_to_fetch_request(request) {
 
 export function bitarray_request_to_fetch_request(request) {
   let [url, options] = request_common(request)
-  if (options.method !== "GET" && options.method !== "HEAD") options.body = request.body.buffer;
+  if (options.method !== "GET" && options.method !== "HEAD") options.body = request.body.rawBuffer;
   return new globalThis.Request(url, options);
 }
 
@@ -116,13 +116,13 @@ export function setFormData(formData, key, value) {
 
 export function appendBitsFormData(formData, key, value) {
   const f = cloneFormData(formData)
-  f.append(key, new Blob([value.buffer]))
+  f.append(key, new Blob([value.rawBuffer]))
   return f
 }
 
 export function setBitsFormData(formData, key, value) {
   const f = cloneFormData(formData)
-  f.set(key, new Blob([value.buffer]))
+  f.set(key, new Blob([value.rawBuffer]))
   return f
 }
 


### PR DESCRIPTION
Hi!

Currently, when on Gleam 1.9 and higher, reading `.buffer` on BitArray displays a warning.
That PR comes to fix that, but ensures a compatibility with old Gleam versions, so everyone can safely upgrade to next versions of `gleam_fetch`, no matter which version of Gleam they're running on.

As a matter of information, code has been tested on Gleam 1.9.1 and Gleam 1.6.0.

As I wasn't aware if the change should be in the Changelog or not, I did not update it (because it's a silent change for users).