### PR TITLE
Implement RequestInit via FetchOptions

### DIFF
--- a/src/gleam/fetch.gleam
+++ b/src/gleam/fetch.gleam
@@ -55,7 +55,27 @@ pub type BodyReader
 /// |> fetch.raw_send
 /// ```
 @external(javascript, "../gleam_fetch_ffi.mjs", "raw_send")
-pub fn raw_send(a: FetchRequest) -> Promise(Result(FetchResponse, FetchError))
+pub fn raw_send(
+  request: FetchRequest,
+) -> Promise(Result(FetchResponse, FetchError))
+
+/// Call directly `fetch` with a `Request`, `FetchOptions` (`Redirect`),
+/// and convert the result back to Gleam.
+/// Let you get back a `FetchResponse` instead of the Gleam
+/// `gleam/http/response.Response` data.
+///
+/// ```gleam
+/// request.new()
+/// |> request.set_host("example.com")
+/// |> request.set_path("/example")
+/// |> fetch.to_fetch_request
+/// |> fetch.raw_send_options(fetch.Follow)
+/// ```
+@external(javascript, "../gleam_fetch_ffi.mjs", "raw_send_options")
+pub fn raw_send_options(
+  request: FetchRequest,
+  redirect: Redirect,
+) -> Promise(Result(FetchResponse, FetchError))
 
 /// Call `fetch` with a Gleam `Request(String)`, and convert the result back
 /// to Gleam. Use it to send strings or JSON stringified.
@@ -78,6 +98,34 @@ pub fn send(
   request
   |> to_fetch_request
   |> raw_send
+  |> promise.try_await(fn(resp) {
+    promise.resolve(Ok(from_fetch_response(resp)))
+  })
+}
+
+/// Call `fetch` with a Gleam `Request(String)` and `FetchOptions`,
+/// then convert the result back to Gleam.
+/// Use it to send strings or JSON stringified.
+///
+/// If you're looking for something more low-level, take a look at
+/// [`raw_send_options`](#raw_send_options).
+///
+/// ```gleam
+/// let my_data = json.object([#("field", "value")])
+/// request.new()
+/// |> request.set_host("example.com")
+/// |> request.set_path("/example")
+/// |> request.set_body(json.to_string(my_data))
+/// |> request.set_header("content-type", "application/json")
+/// |> fetch.send_options(fetch_options.new())
+/// ```
+pub fn send_options(
+  request: Request(String),
+  options: FetchOptions,
+) -> Promise(Result(Response(FetchBody), FetchError)) {
+  request
+  |> to_fetch_request
+  |> raw_send_options(options.redirect)
   |> promise.try_await(fn(resp) {
     promise.resolve(Ok(from_fetch_response(resp)))
   })
@@ -111,6 +159,36 @@ pub fn send_form_data(
   })
 }
 
+/// Call `fetch` with a Gleam `Request(FormData)` and `FetchOptions`,
+/// then convert the result back to Gleam.
+/// Request will be sent as a `multipart/form-data`, and should be
+/// decoded as-is on servers.
+///
+/// If you're looking for something more low-level, take a look at
+/// [`raw_send_options`](#raw_send_options).
+///
+/// ```gleam
+/// request.new()
+/// |> request.set_host("example.com")
+/// |> request.set_path("/example")
+/// |> request.set_body({
+///   form_data.new()
+///   |> form_data.append("key", "value")
+/// })
+/// |> fetch.send_form_data_options(fetch_options.new())
+/// ```
+pub fn send_form_data_options(
+  request: Request(FormData),
+  options: FetchOptions,
+) -> Promise(Result(Response(FetchBody), FetchError)) {
+  request
+  |> form_data_to_fetch_request
+  |> raw_send_options(options.redirect)
+  |> promise.try_await(fn(resp) {
+    promise.resolve(Ok(from_fetch_response(resp)))
+  })
+}
+
 /// Call `fetch` with a Gleam `Request(FormData)`, and convert the result back
 /// to Gleam. Binary will be sent as-is, and you probably want a proper
 /// content-type added.
@@ -124,7 +202,7 @@ pub fn send_form_data(
 /// |> request.set_path("/example")
 /// |> request.set_body(<<"data">>)
 /// |> request.set_header("content-type", "application/octet-stream")
-/// |> fetch.send_form_data
+/// |> fetch.send_bits
 /// ```
 pub fn send_bits(
   request: Request(BitArray),
@@ -132,6 +210,33 @@ pub fn send_bits(
   request
   |> bitarray_request_to_fetch_request
   |> raw_send
+  |> promise.try_await(fn(resp) {
+    promise.resolve(Ok(from_fetch_response(resp)))
+  })
+}
+
+/// Call `fetch` with a Gleam `Request(FormData)` and `FetchOptions`,
+/// then convert the result back to Gleam. Binary will be sent as-is,
+/// and you probably want a proper content-type added.
+///
+/// If you're looking for something more low-level, take a look at
+/// [`raw_send_options`](#raw_send_options).
+///
+/// ```gleam
+/// request.new()
+/// |> request.set_host("example.com")
+/// |> request.set_path("/example")
+/// |> request.set_body(<<"data">>)
+/// |> request.set_header("content-type", "application/octet-stream")
+/// |> fetch.send_bits_options(fetch_options.new())
+/// ```
+pub fn send_bits_options(
+  request: Request(BitArray),
+  options: FetchOptions,
+) -> Promise(Result(Response(FetchBody), FetchError)) {
+  request
+  |> bitarray_request_to_fetch_request
+  |> raw_send_options(options.redirect)
   |> promise.try_await(fn(resp) {
     promise.resolve(Ok(from_fetch_response(resp)))
   })
@@ -293,3 +398,49 @@ pub fn stream_body(
 pub fn read_chunk(
   reader: BodyReader,
 ) -> Promise(Result(Option(BitArray), FetchError))
+
+/// Gleam equivalent of JavaScript
+/// [`RequestInit`](https://developer.mozilla.org/docs/Web/API/RequestInit).
+/// 
+/// The Node target supports only the `redirect` and `priority` options.
+pub opaque type FetchOptions {
+  Builder(redirect: Redirect)
+}
+
+/// Redirect options, for details see
+/// [`redirect`](https://developer.mozilla.org/docs/Web/API/RequestInit#redirect).
+/// 
+/// Change the redirect behaviour of a request.
+pub type Redirect {
+  /// Automatically redirects request.
+  Follow
+  /// Errors out on redirect.
+  Error
+  /// Expects user to handle redirects manually.
+  Manual
+}
+
+/// Creates new `FetchOptions` object with default values.
+///
+/// Useful if more precise control over fetch is required, such as using
+/// signals, cache options and so on.
+///
+/// ```gleam
+/// let options = fetch_options.new()
+///   |> fetch_options.redirect(fetch_options.Follow)
+/// ```
+pub fn fetch_options() -> FetchOptions {
+  Builder(redirect: Follow)
+}
+
+/// Set the
+/// [`redirect`](https://developer.mozilla.org/docs/Web/API/RequestInit#redirect)
+/// option of `FetchOptions`.
+///
+/// ```gleam
+/// let options = fetch_options.new()
+///   |> fetch_options.redirect(fetch_options.Follow)
+/// ```
+pub fn redirect(fetch_options: FetchOptions, which: Redirect) -> FetchOptions {
+  Builder(..fetch_options, redirect: which)
+}

--- a/src/gleam/fetch.gleam
+++ b/src/gleam/fetch.gleam
@@ -74,6 +74,11 @@ pub fn raw_send(
 @external(javascript, "../gleam_fetch_ffi.mjs", "raw_send_options")
 pub fn raw_send_options(
   request: FetchRequest,
+  cache: Cache,
+  credentials: Credentials,
+  keepalive: Bool,
+  mode: Cors,
+  priority: Priority,
   redirect: Redirect,
 ) -> Promise(Result(FetchResponse, FetchError))
 
@@ -125,7 +130,14 @@ pub fn send_options(
 ) -> Promise(Result(Response(FetchBody), FetchError)) {
   request
   |> to_fetch_request
-  |> raw_send_options(options.redirect)
+  |> raw_send_options(
+    options.cache,
+    options.credentials,
+    options.keepalive,
+    options.mode,
+    options.priority,
+    options.redirect,
+  )
   |> promise.try_await(fn(resp) {
     promise.resolve(Ok(from_fetch_response(resp)))
   })
@@ -183,7 +195,14 @@ pub fn send_form_data_options(
 ) -> Promise(Result(Response(FetchBody), FetchError)) {
   request
   |> form_data_to_fetch_request
-  |> raw_send_options(options.redirect)
+  |> raw_send_options(
+    options.cache,
+    options.credentials,
+    options.keepalive,
+    options.mode,
+    options.priority,
+    options.redirect,
+  )
   |> promise.try_await(fn(resp) {
     promise.resolve(Ok(from_fetch_response(resp)))
   })
@@ -236,7 +255,14 @@ pub fn send_bits_options(
 ) -> Promise(Result(Response(FetchBody), FetchError)) {
   request
   |> bitarray_request_to_fetch_request
-  |> raw_send_options(options.redirect)
+  |> raw_send_options(
+    options.cache,
+    options.credentials,
+    options.keepalive,
+    options.mode,
+    options.priority,
+    options.redirect,
+  )
   |> promise.try_await(fn(resp) {
     promise.resolve(Ok(from_fetch_response(resp)))
   })
@@ -404,7 +430,81 @@ pub fn read_chunk(
 /// 
 /// The Node target supports only the `redirect` and `priority` options.
 pub opaque type FetchOptions {
-  Builder(redirect: Redirect)
+  Builder(
+    cache: Cache,
+    credentials: Credentials,
+    keepalive: Bool,
+    mode: Cors,
+    priority: Priority,
+    redirect: Redirect,
+  )
+}
+
+/// Cache options, for details see
+/// [`cache`](https://developer.mozilla.org/docs/Web/API/RequestInit#cache).
+/// 
+/// Change how responses are stored and retrieved from cache.
+pub type Cache {
+  /// Default cache behaviour.
+  ///
+  /// Fresh record will be returned from the cache.
+  /// If the record in cache is stale and server responds with not
+  /// changed, then the value from cache is used. Otherwise makes normal
+  /// request and updates the cache.
+  Default
+  /// Response is not fetched from the cache and not stored in the cache.
+  NoStore
+  /// Response is not fetched from the cache but gets stored.
+  Reload
+  /// If the record in cache is fresh or stale and server responds with not
+  /// changed, then the value from cache is used. Otherwise makes normal
+  /// request and updates the cache.
+  NoCache
+  /// If record is in cache, it is always used. Otherwise makes normal 
+  /// request.
+  ForceCache
+}
+
+/// Credentials options, for details see
+/// [`credentials`](https://developer.mozilla.org/docs/Web/API/RequestInit#credentials).
+/// 
+/// Control whether browser sends credentials with the request and whether
+/// Set-Cookie response headers are respected.
+pub type Credentials {
+  /// Never send credentials or include credentials in the response.
+  CredentialsOmit
+  /// Only send and include credentials for same-origin requests.
+  CredentialsSameOrigin
+  /// Always include credentials.
+  CredentialsInclude
+}
+
+/// CORS options, for details see
+/// [`mode`](https://developer.mozilla.org/docs/Web/API/RequestInit#mode).
+/// 
+/// Set cross-origin behaviour of a request.
+pub type Cors {
+  /// Disallows cross-origin requests.
+  SameOrigin
+  /// Defaults to
+  /// [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS)
+  /// mechanism.
+  Cors
+  /// Disables CORS for cross-origin requests.
+  NoCors
+}
+
+/// Priority options, for details see
+/// [`priority`](https://developer.mozilla.org/docs/Web/API/RequestInit#priority).
+/// 
+/// Increase priority of a request relative to other requests.
+pub type Priority {
+  /// Higher priority.
+  High
+  /// Lower priority.
+  Low
+  /// No preference of priority.
+  Auto
 }
 
 /// Redirect options, for details see
@@ -430,7 +530,77 @@ pub type Redirect {
 ///   |> fetch_options.redirect(fetch_options.Follow)
 /// ```
 pub fn fetch_options() -> FetchOptions {
-  Builder(redirect: Follow)
+  Builder(
+    cache: Default,
+    credentials: CredentialsSameOrigin,
+    keepalive: False,
+    mode: Cors,
+    priority: Auto,
+    redirect: Follow,
+  )
+}
+
+/// Set the
+/// [`cache`](https://developer.mozilla.org/docs/Web/API/RequestInit#cache)
+/// option of `FetchOptions`.
+///
+/// ```gleam
+/// let options = fetch_options.new()
+///   |> fetch_options.cache(fetch_options.NoStore)
+/// ```
+pub fn cache(fetch_options: FetchOptions, which: Cache) -> FetchOptions {
+  Builder(..fetch_options, cache: which)
+}
+
+/// Set the
+/// [`credentials`](https://developer.mozilla.org/docs/Web/API/RequestInit#credentials)
+/// option of `FetchOptions`.
+///
+/// ```gleam
+/// let options = fetch_options.new()
+///   |> fetch_options.credentials(fetch_options.CredentialsOmit)
+/// ```
+pub fn credentials(
+  fetch_options: FetchOptions,
+  which: Credentials,
+) -> FetchOptions {
+  Builder(..fetch_options, credentials: which)
+}
+
+/// Set the
+/// [`keepalive`](https://developer.mozilla.org/docs/Web/API/RequestInit#keepalive)
+/// option of `FetchOptions`.
+///
+/// ```gleam
+/// let options = fetch_options.new()
+///   |> fetch_options.keepalive(True)
+/// ```
+pub fn keepalive(fetch_options: FetchOptions, keepalive: Bool) -> FetchOptions {
+  Builder(..fetch_options, keepalive: keepalive)
+}
+
+/// Set the
+/// [`mode`](https://developer.mozilla.org/docs/Web/API/RequestInit#mode)
+/// option of `FetchOptions`.
+///
+/// ```gleam
+/// let options = fetch_options.new()
+///   |> fetch_options.mode(fetch_options.SameOrigin)
+/// ```
+pub fn mode(fetch_options: FetchOptions, which: Cors) -> FetchOptions {
+  Builder(..fetch_options, mode: which)
+}
+
+/// Set the
+/// [`priority`](https://developer.mozilla.org/docs/Web/API/RequestInit#priority)
+/// option of `FetchOptions`.
+///
+/// ```gleam
+/// let options = fetch_options.new()
+///   |> fetch_options.cors(fetch_options.High)
+/// ```
+pub fn priority(fetch_options: FetchOptions, which: Priority) -> FetchOptions {
+  Builder(..fetch_options, priority: which)
 }
 
 /// Set the

--- a/src/gleam_fetch_ffi.mjs
+++ b/src/gleam_fetch_ffi.mjs
@@ -17,6 +17,20 @@ import {
   FetchError$NetworkError,
   FetchError$InvalidJsonBody,
   FetchError$UnableToReadBody,
+  Cache$isDefault,
+  Cache$isNoStore,
+  Cache$isReload,
+  Cache$isNoCache,
+  Cache$isForceCache,
+  Credentials$isCredentialsOmit,
+  Credentials$isCredentialsSameOrigin,
+  Credentials$isCredentialsInclude,
+  Cors$isSameOrigin,
+  Cors$isCors,
+  Cors$isNoCors,
+  Priority$isHigh,
+  Priority$isLow,
+  Priority$isAuto,
   Redirect$isFollow,
   Redirect$isError,
   Redirect$isManual,
@@ -217,13 +231,78 @@ export function keysFormData(formData) {
 
 // FetchOptions functions.
 
-export async function raw_send_options(request, redirect) {
+export async function raw_send_options(
+  request,
+  cache,
+  credentials,
+  keepalive,
+  cors,
+  priority,
+  redirect,
+) {
   try {
     return Result$Ok(await fetch(request, {
+      cache: convertCache(cache),
+      credentials: convertCredentials(credentials),
+      keepalive,
+      mode: convertCors(cors),
+      priority: convertPriority(priority),
       redirect: convertRedirect(redirect),
     }));
   } catch (error) {
     return Result$Error(FetchError$NetworkError(error.toString()));
+  }
+}
+
+function convertCache(cache) {
+  if (Cache$isDefault(cache)) {
+    return "default";
+  } else if (Cache$isNoStore(cache)) {
+    return "no-store";
+  } else if (Cache$isReload(cache)) {
+    return "reload";
+  } else if (Cache$isNoCache(cache)) {
+    return "no-cache";
+  } else if (Cache$isForceCache(cache)) {
+    return "force-cache";
+  } else {
+    throw new Error("Unsupported cache option");
+  }
+}
+
+function convertCredentials(credentials) {
+  if (Credentials$isCredentialsOmit(credentials)) {
+    return "omit";
+  } else if (Credentials$isCredentialsSameOrigin(credentials)) {
+    return "same-origin";
+  } else if (Credentials$isCredentialsInclude(credentials)) {
+    return "include";
+  } else {
+    throw new Error("Unsupported credentials option");
+  }
+}
+
+function convertCors(cors) {
+  if (Cors$isSameOrigin(cors)) {
+    return "same-origin";
+  } else if (Cors$isCors(cors)) {
+    return "cors";
+  } else if (Cors$isNoCors(cors)) {
+    return "no-cors";
+  } else {
+    throw new Error("Unsupported mode option");
+  }
+}
+
+function convertPriority(priority) {
+  if (Priority$isHigh(priority)) {
+    return "high";
+  } else if (Priority$isLow(priority)) {
+    return "low";
+  } else if (Priority$isAuto(priority)) {
+    return "auto";
+  } else {
+    throw new Error("Unsupported priority option");
   }
 }
 

--- a/src/gleam_fetch_ffi.mjs
+++ b/src/gleam_fetch_ffi.mjs
@@ -17,6 +17,9 @@ import {
   FetchError$NetworkError,
   FetchError$InvalidJsonBody,
   FetchError$UnableToReadBody,
+  Redirect$isFollow,
+  Redirect$isError,
+  Redirect$isManual,
 } from "../gleam_fetch/gleam/fetch.mjs";
 
 export async function raw_send(request) {
@@ -210,4 +213,28 @@ export function keysFormData(formData) {
     result.add(key);
   }
   return arrayToList([...result].reverse());
+}
+
+// FetchOptions functions.
+
+export async function raw_send_options(request, redirect) {
+  try {
+    return Result$Ok(await fetch(request, {
+      redirect: convertRedirect(redirect),
+    }));
+  } catch (error) {
+    return Result$Error(FetchError$NetworkError(error.toString()));
+  }
+}
+
+function convertRedirect(redirect) {
+  if (Redirect$isFollow(redirect)) {
+    return "follow";
+  } else if (Redirect$isError(redirect)) {
+    return "error";
+  } else if (Redirect$isManual(redirect)) {
+    return "manual";
+  } else {
+    throw new Error("Unsupported redirect option");
+  }
 }

--- a/test/gleam_fetch_test.gleam
+++ b/test/gleam_fetch_test.gleam
@@ -236,3 +236,56 @@ fn setup_form_data() {
   |> form_data.append("second-key", "second-value")
   |> form_data.append_bits("second-key", <<"second-value-bits":utf8>>)
 }
+
+// Node only supports `redirect` option.
+pub fn complex_fetch_options_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let options =
+    fetch.fetch_options()
+    |> fetch.redirect(fetch.Follow)
+
+  use result <- promise.await(fetch.send_options(req, options))
+
+  let assert Ok(resp) = result
+  let assert 200 = resp.status
+
+  promise.resolve(Nil)
+}
+
+pub fn fetch_redirect_test() {
+  // Initiates redirect
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("postman-echo.com")
+
+  let options_follow =
+    fetch.fetch_options()
+    |> fetch.redirect(fetch.Follow)
+
+  let options_error =
+    fetch.fetch_options()
+    |> fetch.redirect(fetch.Error)
+
+  let options_manual =
+    fetch.fetch_options()
+    |> fetch.redirect(fetch.Manual)
+
+  use result_follow <- promise.await(fetch.send_options(req, options_follow))
+  use result_error <- promise.await(fetch.send_options(req, options_error))
+  use result_manual <- promise.await(fetch.send_options(req, options_manual))
+
+  let assert Ok(resp) = result_follow
+  let assert 200 = resp.status
+  let assert Error(_) = result_error
+  let assert Ok(resp) = result_manual
+  let assert 302 = resp.status
+
+  promise.resolve(Nil)
+}

--- a/test/gleam_fetch_test.gleam
+++ b/test/gleam_fetch_test.gleam
@@ -248,11 +248,222 @@ pub fn complex_fetch_options_test() {
 
   let options =
     fetch.fetch_options()
+    |> fetch.cache(fetch.NoStore)
+    |> fetch.mode(fetch.Cors)
+    |> fetch.credentials(fetch.CredentialsOmit)
+    |> fetch.keepalive(True)
+    |> fetch.priority(fetch.High)
     |> fetch.redirect(fetch.Follow)
 
   use result <- promise.await(fetch.send_options(req, options))
 
   let assert Ok(resp) = result
+  let assert 200 = resp.status
+
+  promise.resolve(Nil)
+}
+
+// Node doesn't support `cache` option, let's check that it passes at least.
+// For further reference see:
+// https://github.com/node-fetch/node-fetch#class-request
+pub fn fetch_cache_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let options_default =
+    fetch.fetch_options()
+    |> fetch.cache(fetch.Default)
+
+  let options_no_store =
+    fetch.fetch_options()
+    |> fetch.cache(fetch.NoStore)
+
+  let options_reload =
+    fetch.fetch_options()
+    |> fetch.cache(fetch.Reload)
+
+  let options_no_cache =
+    fetch.fetch_options()
+    |> fetch.cache(fetch.NoCache)
+
+  let options_force_cache =
+    fetch.fetch_options()
+    |> fetch.cache(fetch.ForceCache)
+
+  use result_default <- promise.await(fetch.send_options(req, options_default))
+  use result_no_store <- promise.await(fetch.send_options(req, options_no_store))
+  use result_reload <- promise.await(fetch.send_options(req, options_reload))
+  use result_no_cache <- promise.await(fetch.send_options(req, options_no_cache))
+  use result_force_cache <- promise.await(fetch.send_options(
+    req,
+    options_force_cache,
+  ))
+
+  let assert Ok(resp) = result_default
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_no_store
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_reload
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_no_cache
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_force_cache
+  let assert 200 = resp.status
+
+  promise.resolve(Nil)
+}
+
+// Node doesn't support `credentials` option, let's check that it passes at least.
+// For further reference see:
+// https://github.com/node-fetch/node-fetch#class-request
+pub fn fetch_credentials_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let options_omit =
+    fetch.fetch_options()
+    |> fetch.credentials(fetch.CredentialsOmit)
+
+  let options_same_origin =
+    fetch.fetch_options()
+    |> fetch.credentials(fetch.CredentialsSameOrigin)
+
+  let options_include =
+    fetch.fetch_options()
+    |> fetch.credentials(fetch.CredentialsInclude)
+
+  use result_omit <- promise.await(fetch.send_options(req, options_omit))
+  use result_same_origin <- promise.await(fetch.send_options(
+    req,
+    options_same_origin,
+  ))
+  use result_include <- promise.await(fetch.send_options(req, options_include))
+
+  let assert Ok(resp) = result_omit
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_same_origin
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_include
+  let assert 200 = resp.status
+
+  promise.resolve(Nil)
+}
+
+// Node doesn't support `keepalive` option, let's check that it passes at least.
+// For further reference see:
+// https://github.com/node-fetch/node-fetch#class-request
+pub fn fetch_keepalive_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let options_keepalive =
+    fetch.fetch_options()
+    |> fetch.keepalive(True)
+
+  let options_no_keepalive =
+    fetch.fetch_options()
+    |> fetch.keepalive(False)
+
+  use result_keepalive <- promise.await(fetch.send_options(
+    req,
+    options_keepalive,
+  ))
+  use result_no_keepalive <- promise.await(fetch.send_options(
+    req,
+    options_no_keepalive,
+  ))
+
+  let assert Ok(resp) = result_keepalive
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_no_keepalive
+  let assert 200 = resp.status
+
+  promise.resolve(Nil)
+}
+
+// Node doesn't support `mode` option, let's check that it passes at least.
+// For further reference see:
+// https://github.com/node-fetch/node-fetch#class-request
+pub fn fetch_mode_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let options_same_origin =
+    fetch.fetch_options()
+    |> fetch.mode(fetch.SameOrigin)
+
+  let options_cors =
+    fetch.fetch_options()
+    |> fetch.mode(fetch.Cors)
+
+  let options_no_cors =
+    fetch.fetch_options()
+    |> fetch.mode(fetch.NoCors)
+
+  use result_same_origin <- promise.await(fetch.send_options(
+    req,
+    options_same_origin,
+  ))
+  use result_cors <- promise.await(fetch.send_options(req, options_cors))
+  use result_no_cors <- promise.await(fetch.send_options(req, options_no_cors))
+
+  let assert Ok(resp) = result_same_origin
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_cors
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_no_cors
+  let assert 200 = resp.status
+
+  promise.resolve(Nil)
+}
+
+// It's difficult to test `priority` as it just increases the probability
+// of finishing first
+pub fn fetch_priority_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let options_high =
+    fetch.fetch_options()
+    |> fetch.priority(fetch.High)
+
+  let options_low =
+    fetch.fetch_options()
+    |> fetch.priority(fetch.Low)
+
+  let options_auto =
+    fetch.fetch_options()
+    |> fetch.priority(fetch.Auto)
+
+  use result_high <- promise.await(fetch.send_options(req, options_high))
+  use result_low <- promise.await(fetch.send_options(req, options_low))
+  use result_auto <- promise.await(fetch.send_options(req, options_auto))
+
+  let assert Ok(resp) = result_high
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_low
+  let assert 200 = resp.status
+  let assert Ok(resp) = result_auto
   let assert 200 = resp.status
 
   promise.resolve(Nil)


### PR DESCRIPTION
Does not fully implement RequestInit, only what seemed useful.

Closes: #4
Deprecates: #5 